### PR TITLE
FMPPartialStock null deserialization

### DIFF
--- a/src/stock.rs
+++ b/src/stock.rs
@@ -69,10 +69,10 @@ impl Client {
 #[serde(rename_all = "camelCase")]
 pub struct FMPPartialStock {
     pub symbol: String,
-    pub name: String,
-    pub price: f64,
-    pub exchange: String,
-    pub exchange_short_name: String,
+    pub name: Option<String>,
+    pub price: Option<f64>,
+    pub exchange: Option<String>,
+    pub exchange_short_name: Option<String>,
     #[serde(rename = "type")]
     pub type_field: String,
 }


### PR DESCRIPTION
The`stock_list` function calls the `/v3/stock/list` FMP api but panics when trying to deserialize the response into JSON. 
This is because FMP does not enforce that all response fields are defined (i.e. some of them are null).

I only made the FMPPartialStock struct attributes that errored when trying to deserialize; it may be necessary to make everything except for `symbol` optional.